### PR TITLE
Corregir error de tipo boolean en configuración de Supabase

### DIFF
--- a/falta-uno/src/config/supabase.ts
+++ b/falta-uno/src/config/supabase.ts
@@ -14,6 +14,5 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
     storage: AsyncStorage,
     autoRefreshToken: true,
     persistSession: true,
-    detectSessionInUrl: false,
   },
 });


### PR DESCRIPTION
Eliminar la propiedad detectSessionInUrl de la configuración del cliente de Supabase para resolver el error "TypeError: expected dynamic type 'boolean', but had type 'string'" en Expo Go.

detectSessionInUrl no es necesaria en React Native/Expo y puede causar conflictos de tipo en el runtime nativo.