### PR TITLE
Corregir error de tipo boolean en Expo Go

### DIFF
--- a/falta-uno/app.json
+++ b/falta-uno/app.json
@@ -6,7 +6,7 @@
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
-    "newArchEnabled": true,
+    "newArchEnabled": false,
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",

--- a/falta-uno/src/screens/LoginScreen.tsx
+++ b/falta-uno/src/screens/LoginScreen.tsx
@@ -58,7 +58,7 @@ export default function LoginScreen({ navigation }: any) {
             placeholder="Contraseña"
             value={password}
             onChangeText={setPassword}
-            secureTextEntry
+            secureTextEntry={true}
             editable={!loading}
           />
 

--- a/falta-uno/src/screens/RegisterScreen.tsx
+++ b/falta-uno/src/screens/RegisterScreen.tsx
@@ -117,7 +117,7 @@ export default function RegisterScreen({ navigation }: any) {
               placeholder="Contraseña"
               value={password}
               onChangeText={setPassword}
-              secureTextEntry
+              secureTextEntry={true}
               editable={!loading}
             />
 
@@ -126,7 +126,7 @@ export default function RegisterScreen({ navigation }: any) {
               placeholder="Confirmar contraseña"
               value={confirmPassword}
               onChangeText={setConfirmPassword}
-              secureTextEntry
+              secureTextEntry={true}
               editable={!loading}
             />
 


### PR DESCRIPTION
- Agregar valor explícito true a secureTextEntry en LoginScreen y RegisterScreen
- Deshabilitar newArchEnabled en app.json para mejor compatibilidad
- Esto resuelve el error: "TypeError: expected dynamic type 'boolean', but had type 'string'"